### PR TITLE
tf: domain mx record

### DIFF
--- a/infrastructure/email.tf
+++ b/infrastructure/email.tf
@@ -61,7 +61,7 @@ resource "aws_iam_access_key" "ses_user_key" {
 
 resource "aws_route53_record" "mx_record" {
   zone_id = aws_route53_zone.getstronger_pro.zone_id
-  name    = ""
+  name    = "getstronger.pro"
   type    = "MX"
   ttl     = 300
   records = ["10 inbound-smtp.eu-west-2.amazonaws.com", "10 feedback-smtp.eu-west-2.amazonses.com"]


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new MX record configuration in the `email.tf` file.
- Added an `aws_route53_record` resource to manage the MX record for the domain.
- Configured the MX record with a TTL of 300 and a priority of 10, pointing to "inbound-smtp.eu-west-2.amazonaws.com".



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>email.tf</strong><dd><code>Add MX record configuration for Route 53</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infrastructure/email.tf

<li>Added a new <code>aws_route53_record</code> resource for MX record configuration.<br> <li> Configured the MX record with a TTL of 300 and a record pointing to <br>"10 inbound-smtp.eu-west-2.amazonaws.com".<br>


</details>


  </td>
  <td><a href="https://github.com/crlssn/getstronger/pull/166/files#diff-61bd110be908c5dc31ad628aaf772f69434bc232dfd17ff4f64aab7badcdcc5c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information