### PR TITLE
fix: bypass tracing for streaming endpoints

### DIFF
--- a/server/rpc/middlewares/middlewares.go
+++ b/server/rpc/middlewares/middlewares.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/cors"
 
 	"github.com/crlssn/getstronger/server/pkg/config"
+	"github.com/crlssn/getstronger/server/pkg/pb/api/v1/apiv1connect"
 	"github.com/crlssn/getstronger/server/pkg/trace"
 	"github.com/crlssn/getstronger/server/pkg/xcontext"
 )
@@ -71,8 +72,8 @@ func (m *Middleware) cookies(h http.Handler) http.Handler {
 
 func (m *Middleware) trace(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if _, ok := w.(http.Flusher); ok {
-			// Bypass tracing for streaming requests.
+		// DEBT: Hacky workaround to bypass tracing for streaming endpoints.
+		if r.RequestURI == apiv1connect.NotificationServiceUnreadNotificationsProcedure {
 			h.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Refined the tracing middleware to bypass tracing only for the `NotificationServiceUnreadNotificationsProcedure` endpoint instead of all streaming requests.
- Updated import statements to include the necessary `apiv1connect` package for endpoint identification.
- Added a comment indicating the workaround as technical debt for future improvement.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middlewares.go</strong><dd><code>Refined tracing bypass logic for specific streaming endpoint</code></dd></summary>
<hr>

server/rpc/middlewares/middlewares.go

<li>Added a specific condition to bypass tracing for the <br><code>NotificationServiceUnreadNotificationsProcedure</code> endpoint.<br> <li> Removed the generic bypass for all streaming requests using <br><code>http.Flusher</code>.<br> <li> Updated import statements to include <code>apiv1connect</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/crlssn/getstronger/pull/191/files#diff-653bff57e63301a8ed453ad4d2c5752e7114310814f9c1d6e2214d36538ed1fd">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information