### PR TITLE
proto: use buf linter

### DIFF
--- a/.github/workflows/test.proto.yml
+++ b/.github/workflows/test.proto.yml
@@ -26,11 +26,12 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-        shell: bash
 
       - name: Generate protos
         run: npx buf generate
-        shell: bash
+
+      - name: Lint protos
+        run: npx buf lint
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -50,9 +51,3 @@ jobs:
             exit 1
           fi
 
-      - name: Install protolint
-        run: go install github.com/yoheimuta/protolint/cmd/protolint@latest
-
-      - name: Run protolint
-        working-directory: ./proto
-        run: protolint .

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,12 @@ run_web:
 
 format:
 	goimports -w .
-	protolint --fix .
 	cd web && npx sort-package-json
 	cd web && npm run format
 
 lint:
 	golangci-lint run
-	protolint .
+	buf lint
 
 vet:
 	go vet ./...


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Replaced the use of `protolint` with `buf lint` for linting protobuf files in both the GitHub Actions workflow and the Makefile.
- Removed steps related to `protolint` installation and execution from the GitHub Actions workflow.
- Updated the `format` and `lint` targets in the Makefile to align with the new linting tool.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test.proto.yml</strong><dd><code>Replace `protolint` with `buf lint` in GitHub Actions workflow.</code></dd></summary>
<hr>

.github/workflows/test.proto.yml

<li>Added a step to lint protobuf files using <code>buf lint</code>.<br> <li> Removed steps related to installing and running <code>protolint</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/crlssn/getstronger/pull/198/files#diff-4c5f6e74e0443062713b5fc1051ca5cfaea7a560ad1e92b7134d9a552cbce9da">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update Makefile to use `buf lint` instead of `protolint`.</code></dd></summary>
<hr>

Makefile

<li>Replaced <code>protolint</code> commands with <code>buf lint</code> for linting protobuf files.<br> <li> Removed <code>protolint</code> fix command from the <code>format</code> target.<br>


</details>


  </td>
  <td><a href="https://github.com/crlssn/getstronger/pull/198/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information