### PR TITLE
refact: web: drop alert error code

### DIFF
--- a/web/src/http/requests.ts
+++ b/web/src/http/requests.ts
@@ -492,7 +492,7 @@ const tryCatch = async <T>(fn: () => Promise<T>): Promise<T | void> => {
       // DEBT: Filter out some error codes to alert the user until we have a better way to handle them.
       const ignoredCodes: Code[] = [Code.Unauthenticated, Code.Unavailable, Code.Canceled]
       if (!ignoredCodes.includes(error.code)) {
-        alert(`${error.code}: ${error.message}`)
+        alert(error.message)
         return
       }
     }


### PR DESCRIPTION
It's an integer and does not provide any benefits to the user