### PR TITLE
cicd: don't cancel in progress jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: deploy-main
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Cancelling jobs that involve terraform or database changes is dangerous