### PR TITLE
chore: randomly assign server port for e2e test

### DIFF
--- a/server/testing/e2e/e2e_test.go
+++ b/server/testing/e2e/e2e_test.go
@@ -3,6 +3,9 @@ package e2e_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"math/rand"
+	"net"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -134,11 +137,29 @@ func options() []fx.Option {
 			protovalidate.New,
 			func() *config.Config {
 				return &config.Config{
-					DB:     config.DB{},
-					JWT:    config.JWT{},
-					Server: config.Server{Port: "65432"},
+					DB:  config.DB{},
+					JWT: config.JWT{},
+					Server: config.Server{
+						Port: randomUnusedPort(),
+					},
 				}
 			},
 		),
 	}
+}
+
+func randomUnusedPort() string {
+	for range 20 {
+		// Find random port in range [1024, 65535).
+		port := rand.Intn(65535-1024) + 1024 //nolint:gosec
+		address := fmt.Sprintf(":%d", port)
+		listener, err := net.Listen("tcp", address)
+		if err == nil {
+			if err = listener.Close(); err != nil {
+				panic(fmt.Sprintf("could not close listener: %v", err))
+			}
+			return fmt.Sprintf("%d", port)
+		}
+	}
+	panic("could not find an unused port after 20 attempts")
 }

--- a/server/testing/e2e/e2e_test.go
+++ b/server/testing/e2e/e2e_test.go
@@ -152,8 +152,7 @@ func randomUnusedPort() string {
 	for range 20 {
 		// Find random port in range [1024, 65535).
 		port := rand.Intn(65535-1024) + 1024 //nolint:gosec
-		address := fmt.Sprintf(":%d", port)
-		listener, err := net.Listen("tcp", address)
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 		if err == nil {
 			if err = listener.Close(); err != nil {
 				panic(fmt.Sprintf("could not close listener: %v", err))


### PR DESCRIPTION
This is an attempt to resolve https://github.com/crlssn/getstronger/issues/440